### PR TITLE
Triggerboard: set max-age header

### DIFF
--- a/examples/osd/triggerbaord/resources/res-event.c
+++ b/examples/osd/triggerbaord/resources/res-event.c
@@ -93,6 +93,9 @@ res_get_handler(void *request, void *response, uint8_t *buffer, uint16_t preferr
   }
 
   /* A post_handler that handles subscriptions/observing will be called for periodic resources by the framework. */
+	
+	// tell client when to schedule re-registration: 1 Hour
+	REST.set_header_max_age(response, /* uint32_t, Seconds */ 3600);
 }
 /*
  * Additionally, res_event_handler must be implemented for each EVENT_RESOURCE.

--- a/examples/osd/triggerbaord/sketch.pde
+++ b/examples/osd/triggerbaord/sketch.pde
@@ -45,11 +45,13 @@ void setup (void)
     SENSORS_ACTIVATE(button_sensor);
     // init coap resourcen
     rest_init_engine ();
+    #pragma GCC diagnostic ignored "-Wwrite-strings"
     rest_activate_resource (&res_led, "s/led");
     rest_activate_resource (&res_bled, "s/bled");
     rest_activate_resource (&res_battery, "s/battery");
     rest_activate_resource (&res_cputemp, "s/cputemp");
     rest_activate_resource(&res_event, "s/button");         
+    #pragma GCC diagnostic pop
 
 //    NETSTACK_MAC.off(1);
 }


### PR DESCRIPTION
To tell some (CoAP.NET based/?)observing clients to back off for an hour before re-registering.