### PR TITLE
tunslip6: gettimeofday needs sys/time.6

### DIFF
--- a/tools/tunslip6.c
+++ b/tools/tunslip6.c
@@ -40,6 +40,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
+#include <sys/time.h>
 #include <sys/types.h>
 
 #include <unistd.h>


### PR DESCRIPTION
This fixes:

  $ make tunslip6
  cc     tunslip6.c tools-utils.c   -o tunslip6
  tunslip6.c: In function ‘stamptime’:
  tunslip6.c:134:3: warning: implicit declaration of function
  ‘gettimeofday’ [-Wimplicit-function-declaration]
     gettimeofday(&tv, NULL) ;
     ^~~~~~~~~~~~