### PR TITLE
rf230_last_rssi is rssi value in dBm, fixed RF230_MIN_RX_POWER also i…

### DIFF
--- a/cpu/avr/radio/rf230bb/halbb.c
+++ b/cpu/avr/radio/rf230bb/halbb.c
@@ -667,7 +667,7 @@ ISR(TRX24_RX_START_vect)
 //	DEBUGFLOW('3');
 /* Save RSSI for this packet if not in extended mode, scaling to 1dB resolution */
 #if !RF230_CONF_AUTOACK
-    rf230_last_rssi = 3 * hal_subregister_read(SR_RSSI);
+    rf230_last_rssi = 90 - 3 * hal_subregister_read(SR_RSSI);
 #endif
     rf230_get_last_rx_packet_timestamp();
 }
@@ -751,6 +751,7 @@ HAL_RF230_ISR()
 #else  // Faster with 1-clock multiply. Raven and Jackdaw have 2-clock multiply so same speed while saving 2 bytes of program memory
         rf230_last_rssi = 3 * hal_subregister_read(SR_RSSI);
 #endif
+      rf230_last_rssi -= 90;
 #endif
 
     }
@@ -768,7 +769,7 @@ HAL_RF230_ISR()
          /* Save the rssi for printing in the main loop */
 #if RF230_CONF_AUTOACK
          //rf230_last_rssi=hal_subregister_read(SR_ED_LEVEL);
-         rf230_last_rssi=hal_register_read(RG_PHY_ED_LEVEL);
+         rf230_last_rssi=90 - hal_register_read(RG_PHY_ED_LEVEL);
 #endif
          if (rf230_last_rssi >= RF230_MIN_RX_POWER) {
 #endif

--- a/cpu/avr/radio/rf230bb/rf230bb.h
+++ b/cpu/avr/radio/rf230bb/rf230bb.h
@@ -225,7 +225,7 @@ void rf230_set_promiscuous_mode(bool isPromiscuous);
 bool rf230_is_ready_to_send();
 extern int8_t rf230_last_correlation,rf230_last_rssi,rf230_smallest_rssi;
 
-uint8_t rf230_get_raw_rssi(void);
+int8_t rf230_get_raw_rssi(void);
 int rf230_aes_encrypt_ecb(unsigned char *key, unsigned char *plain, unsigned char *cipher);
 int rf230_aes_decrypt_ecb(unsigned char *key, unsigned char *cipher, unsigned char *plain);
 int rf230_aes_encrypt_cbc(unsigned char *key, unsigned char *plain, int len, unsigned char *mic);

--- a/examples/osd/arduino-merkurboard/resources/resource_min_rssi.c
+++ b/examples/osd/arduino-merkurboard/resources/resource_min_rssi.c
@@ -1,0 +1,49 @@
+/**
+ * \file
+ *      Resource to get rf230_smallest_rssi
+ * \author
+ *      Marcus Priesch <marcus@priesch.co.at>
+ *
+ * \brief get min rssi since last call (min rssi gets reset after the call)
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "contiki.h"
+#include "jsonparse.h"
+#include "er-coap.h"
+#include "generic_resource.h"
+#include "Arduino.h"
+
+extern int8_t rf230_smallest_rssi;
+
+size_t
+linkstats_to_string
+    ( const char *name
+    , const char *uri
+    , const char *query
+    , char *buf
+    , size_t bufsize
+    )
+{
+  size_t res;
+  res = snprintf (buf, bufsize, "%d", rf230_smallest_rssi);
+  rf230_smallest_rssi = 0;
+  return res;
+}
+
+GENERIC_RESOURCE \
+    ( linkstats
+    , LINKSTATS
+    , linkstats
+    , 0
+    , 0
+    , linkstats_to_string
+    );
+
+/*
+ * VI settings, see coding style
+ * ex:ts=8:et:sw=4
+ */

--- a/examples/osd/arduino-merkurboard/sketch.pde
+++ b/examples/osd/arduino-merkurboard/sketch.pde
@@ -16,7 +16,7 @@ extern "C" {
 #include "net/netstack.h"
 #include "ota-update.h"
 
-extern resource_t res_led, res_battery, res_cputemp;
+extern resource_t res_led, res_battery, res_cputemp, res_linkstats;
 
 uint8_t led_pin=4;
 uint8_t led_status;
@@ -34,6 +34,7 @@ void setup (void)
     rest_activate_resource (&res_led, "s/led");
     rest_activate_resource (&res_battery, "s/battery");
     rest_activate_resource (&res_cputemp, "s/cputemp");
+    rest_activate_resource (&res_linkstats, "s/min_rssi");
     OTA_ACTIVATE_RESOURCES();
     #pragma GCC diagnostic pop
 
@@ -42,7 +43,7 @@ void setup (void)
     //NETSTACK_MAC.off(1);
 
     // uncoment if you want to set the loop interval at runtime
-    //#define LOOP_INTERVAL_AFTER_INIT (60 * CLOCK_SECOND)    
+    //#define LOOP_INTERVAL_AFTER_INIT (60 * CLOCK_SECOND)
     //loop_periodic_set (LOOP_INTERVAL_AFTER_INIT);
 
     mcu_sleep_set(128);

--- a/platform/avr-raven/apps/raven-webserver/httpd-cgi.c
+++ b/platform/avr-raven/apps/raven-webserver/httpd-cgi.c
@@ -39,7 +39,7 @@
  * non-zero value indicates that the function has completed and that
  * the web server should move along to the next script line.
  *
- */ 
+ */
 
 #include <stdio.h>
 #include <string.h>
@@ -112,10 +112,11 @@ static const char *states[] = {
 #if RADIOSTATS
   extern unsigned long radioontime;
   static unsigned long savedradioontime;
-  extern uint8_t RF230_radio_on, rf230_last_rssi;
+  extern uint8_t RF230_radio_on;
+  extern int8_t rf230_last_rssi;
   extern uint16_t RF230_sendpackets,RF230_receivepackets,RF230_sendfail,RF230_receivefail;
 #endif
-  
+
 
 void
 web_set_temp(char *s)
@@ -185,7 +186,7 @@ generate_file_stats(void *arg)
 
       /* Get the linked list file entry into RAM from from wherever it is*/
       httpd_memcpy(&fram,f,sizeof(fram));
- 
+
       /* Get the file name from whatever memory it is in */
       httpd_fs_cpy(&tmp, fram.name, sizeof(tmp));
 #if HTTPD_FS_STATISTICS==1
@@ -213,9 +214,9 @@ PT_THREAD(file_stats(struct httpd_state *s, char *ptr))
   PSOCK_BEGIN(&s->sout);
 
   thisfilename=&s->filename[0]; //temporary way to pass filename to generate_file_stats
-  
+
   PSOCK_GENERATOR_SEND(&s->sout, generate_file_stats, (void *) ptr);
-  
+
   PSOCK_END(&s->sout);
 }
 #endif /*HTTPD_FS_STATISTICS*/
@@ -250,7 +251,7 @@ make_tcp_stats(void *arg)
 static
 PT_THREAD(tcp_stats(struct httpd_state *s, char *ptr))
 {
-  
+
   PSOCK_BEGIN(&s->sout);
 
   for(s->u.count = 0; s->u.count < UIP_CONNS; ++s->u.count) {
@@ -303,11 +304,11 @@ uint16_t numprinted;
     if (uip_ds6_if.addr_list[i].isused) {
       j++;
       numprinted += httpd_cgi_sprint_ip6(uip_ds6_if.addr_list[i].ipaddr, uip_appdata + numprinted);
-      numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_addrb); 
+      numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_addrb);
     }
   }
 //if (j==0) numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_addrn);
-  numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_addrf, UIP_DS6_ADDR_NB-j); 
+  numprinted += httpd_snprintf((char *)uip_appdata+numprinted, uip_mss()-numprinted, httpd_cgi_addrf, UIP_DS6_ADDR_NB-j);
   return numprinted;
 }
 /*---------------------------------------------------------------------------*/
@@ -320,7 +321,7 @@ PT_THREAD(addresses(struct httpd_state *s, char *ptr))
 
   PSOCK_END(&s->sout);
 }
-/*---------------------------------------------------------------------------*/	
+/*---------------------------------------------------------------------------*/
 static unsigned short
 make_neighbors(void *p)
 {
@@ -346,11 +347,11 @@ PT_THREAD(neighbors(struct httpd_state *s, char *ptr))
 {
   PSOCK_BEGIN(&s->sout);
 
-  PSOCK_GENERATOR_SEND(&s->sout, make_neighbors, s->u.ptr);  
-  
+  PSOCK_GENERATOR_SEND(&s->sout, make_neighbors, s->u.ptr);
+
   PSOCK_END(&s->sout);
 }
-/*---------------------------------------------------------------------------*/			
+/*---------------------------------------------------------------------------*/
 static unsigned short
 make_routes(void *p)
 {
@@ -384,9 +385,9 @@ static
 PT_THREAD(routes(struct httpd_state *s, char *ptr))
 {
   PSOCK_BEGIN(&s->sout);
- 
-  PSOCK_GENERATOR_SEND(&s->sout, make_routes, s->u.ptr); 
- 
+
+  PSOCK_GENERATOR_SEND(&s->sout, make_routes, s->u.ptr);
+
   PSOCK_END(&s->sout);
 }
 /*---------------------------------------------------------------------------*/
@@ -467,7 +468,7 @@ generate_radio_stats(void *arg)
 
 #if RF230BB
   numprinted+=httpd_snprintf((char *)uip_appdata + numprinted, uip_mss() - numprinted, httpd_cgi_sensor11,\
-    RF230_sendpackets,RF230_receivepackets,RF230_sendfail,RF230_receivefail,-92+rf230_last_rssi);
+    RF230_sendpackets,RF230_receivepackets,RF230_sendfail,RF230_receivefail,rf230_last_rssi);
 #else
   p1=0;
   radio_get_rssi_value(&p1);
@@ -475,7 +476,7 @@ generate_radio_stats(void *arg)
   numprinted+=httpd_snprintf((char *)uip_appdata + numprinted, uip_mss() - numprinted, httpd_cgi_sensor11,\
     RF230_sendpackets,RF230_receivepackets,RF230_sendfail,RF230_receivefail,p1);
 #endif
- 
+
   return numprinted;
 }
 #endif
@@ -490,7 +491,7 @@ PT_THREAD(sensor_readings(struct httpd_state *s, char *ptr))
   PSOCK_GENERATOR_SEND(&s->sout, generate_radio_stats, s);
 #endif
 
-  
+
   PSOCK_END(&s->sout);
 }
 /*---------------------------------------------------------------------------*/
@@ -580,4 +581,3 @@ uint8_t httpd_cgi_sprint_ip6(uip_ip6addr_t addr, char * result)
 
     return (result - starting);
         }
-

--- a/platform/avr-ravenusb/cdc_task.c
+++ b/platform/avr-ravenusb/cdc_task.c
@@ -705,10 +705,10 @@ extern uip_ds6_netif_t uip_ds6_if;
 				PRINTF_P(PSTR("  * TX Power(0=+3dBm, 15=-17.2dBm): %d\n\r"), rf230_get_txpower());
 #endif
 				if (rf230_smallest_rssi) {
-					PRINTF_P(PSTR("  * Current/Last/Smallest RSSI: %d/%d/%ddBm\n\r"), -91+(rf230_rssi()-1), -91+(rf230_last_rssi-1),-91+(rf230_smallest_rssi-1));
+					PRINTF_P(PSTR("  * Current/Last/Smallest RSSI: %d/%d/%ddBm\n\r"), rf230_rssi(), rf230_last_rssi,rf230_smallest_rssi);
 					rf230_smallest_rssi=0;
 				} else {
-					PRINTF_P(PSTR("  * Current/Last/Smallest RSSI: %d/%d/--dBm\n\r"), -91+(rf230_rssi()-1), -91+(rf230_last_rssi-1));
+					PRINTF_P(PSTR("  * Current/Last/Smallest RSSI: %d/%d/--dBm\n\r"), rf230_rssi(), rf230_last_rssi);
 				}
 
 #else /* RF230BB */
@@ -718,7 +718,7 @@ extern uip_ds6_netif_t uip_ds6_if;
 					PRINTF_P(PSTR("  * Current RSSI: "));
 					int8_t rssi = 0;
 					if(radio_get_rssi_value(&rssi)==RADIO_SUCCESS)
-						PRINTF_P(PSTR("%ddB\n\r"), -91+3*(rssi-1));
+						PRINTF_P(PSTR("%ddBm\n\r"), rssi);
 					else
 						PRINTF_P(PSTR("Unknown\n\r"));
 				}
@@ -892,4 +892,3 @@ void vcptx_end_led(void)
     led3_timer = 5;
 }
 /** @}  */
-

--- a/platform/osd-merkur-256/contiki-conf.h
+++ b/platform/osd-merkur-256/contiki-conf.h
@@ -110,18 +110,13 @@ typedef unsigned short uip_stats_t;
  * Leave undefined for full power and sensitivity.
  * tx=0 (3dbm, default) to 15 (-17.2dbm)
  * RF230_CONF_AUTOACK sets the extended mode using the energy-detect register with rx=0 (-91dBm) to 84 (-7dBm)
- *   else the rssi register is used having range 0 (91dBm) to 28 (-10dBm)
- *   For simplicity RF230_MIN_RX_POWER is based on the energy-detect value and divided by 3 when autoack is not set.
+ *   else the rssi register is used having range 0 (-91dBm) to 28 (-10dBm)
+ *   For simplicity RF230_MIN_RX_POWER i specified in dBm also and gets converted to the correct register values
  * On the RF230 a reduced rx power threshold will not prevent autoack if enabled and requested.
- * These numbers applied to both Raven and Jackdaw give a maximum communication distance of about 15 cm
- * and a 10 meter range to a full-sensitivity RF230 sniffer.
-#define RF230_MAX_TX_POWER 15
-#define RF230_MIN_RX_POWER 30
  */
   /* The rf231, atmega128rfa1 and atmega256rfr2 can use an rssi
    * threshold for triggering rx_busy that saves 0.5ma in rx mode
-   * 1 - 15 maps into -90 to -48 dBm; the register is written with
-   * RF230_MIN_RX_POWER/6 + 1. Undefine for -100dBm sensitivity
+   * it can be specified in dBm (e.g -78 to drop all frames with rssi below -78dBm)
    */
 //#define RF230_MIN_RX_POWER        0
 


### PR DESCRIPTION
- rework to always have rssi in dBm (negative value) in all places - hopefully
- added /s/min_rssi ressource to arduino-merkurboard to query the smallest rssi since last request to this resource
- RF230_MIN_RX_POWER is fixed and supports value in dBm (e.g. -72 ignores all packets that have lower rssi than -72)

fixes are also in other places where rssi gets print out which are not in our scope (e.g. ravenusb) - how to test ? - or should we simply ignore them ?

please review, tests, verify and merge into master ;)

regards,
m.